### PR TITLE
add python requirement file for OCI_idcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.vscode
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-
-.vscode
-.DS_Store

--- a/OCI_idcs.py
+++ b/OCI_idcs.py
@@ -8,6 +8,7 @@
 #
 # Prerequisites: 
 # - Python 3 installed
+# - Python modules: requests, columnar
 # - IDCS OAuth2 application created with Client ID and Client secret available
 #
 # Versions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Columnar==1.3.1
 requests==2.25.0
+oci==2.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Columnar==1.3.1
+requests==2.25.0


### PR DESCRIPTION
- updating prerequisites information on OCI_idcs.py header comments
- Adding python requirement.txt file for easier initial setup.

Next: each python header files should be gradually updated with python requirements and requirements.txt file should reflect requirements for the whole project. This would allow to have all scripts ready with only one virtualenv. 